### PR TITLE
Fix: Prevent 'subscript out of range' error and add MDPI style support(修复：防止下标越界错误并添加 MDPI 样式支持)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This problem is nearly impossible to resolve with VBA scripts, and currently, th
 * [Nature](http://www.zotero.org/styles/nature)
 * [Vancouver](http://www.zotero.org/styles/vancouver)
 * [ACM SIG Proceedings](https://www.zotero.org/styles/acm-sig-proceedings)
+* [Multidisciplinary Digital Publishing Institute (MDPI)](http://www.zotero.org/styles/multidisciplinary-digital-publishing-institute)
 
 ### Author-only styles
 

--- a/ZoteroLinkCitation.bas
+++ b/ZoteroLinkCitation.bas
@@ -1,4 +1,3 @@
-Attribute VB_Name = "ZoteroLinkCitation"
 ' An MS Word macro that links author-date or number style citations to their bibliography entry.
 ' altair_wei@outlook.com
 ' https://github.com/altairwei/ZoteroLinkCitation
@@ -37,7 +36,7 @@ Private Function ParseObj(key$)
                        Else
                            ParseObj key
                        End If
-                
+
             Case "}":  key = ReducePath(key): Exit Do
             Case ":":  key = key & "." & token(p - 1)
             Case ",":  key = ReducePath(key)
@@ -76,11 +75,11 @@ Private Function RExtract(s$, Pattern, Optional bGroup1Bias As Boolean, Optional
     .Pattern = Pattern
     If .TEST(s) Then
       Set m = .Execute(s)
-      ReDim v(1 To m.Count)
+      ReDim v(1 To m.count)
       For Each n In m
         c = c + 1
-        v(c) = n.value
-        If bGroup1Bias Then If Len(n.submatches(0)) Or n.value = """""" Then v(c) = n.submatches(0)
+        v(c) = n.Value
+        If bGroup1Bias Then If Len(n.submatches(0)) Or n.Value = """""" Then v(c) = n.submatches(0)
       Next
     End If
   End With
@@ -97,8 +96,8 @@ End Function
 
 Function GetFilteredValues(dic, match)
     Dim c&, i&, v, w
-    v = dic.keys
-    ReDim w(1 To dic.Count)
+    v = dic.Keys
+    ReDim w(1 To dic.count)
     For i = 0 To UBound(v)
         If v(i) Like match Then
             c = c + 1
@@ -111,7 +110,7 @@ End Function
 
 Function GetFilteredTable(dic, cols)
     Dim c&, i&, j&, v, w, z
-    v = dic.keys
+    v = dic.Keys
     z = GetFilteredValues(dic, cols(0))
     ReDim w(1 To UBound(z), 1 To UBound(cols) + 1)
     For j = 1 To UBound(cols) + 1
@@ -132,20 +131,20 @@ Private Sub QuickSort(arr As Variant, inLow As Long, inHigh As Long)
     Dim tmpSwap As Variant
     Dim low As Long
     Dim high As Long
-    
+
     low = inLow
     high = inHigh
     pivot = arr((low + high) \ 2)
-    
+
     While (low <= high)
         While (arr(low) < pivot And low < inHigh)
             low = low + 1
         Wend
-        
+
         While (pivot < arr(high) And high > inLow)
             high = high - 1
         Wend
-        
+
         If (low <= high) Then
             tmpSwap = arr(low)
             arr(low) = arr(high)
@@ -154,7 +153,7 @@ Private Sub QuickSort(arr As Variant, inLow As Long, inHigh As Long)
             high = high - 1
         End If
     Wend
-    
+
     If (inLow < high) Then QuickSort arr, inLow, high
     If (low < inHigh) Then QuickSort arr, low, inHigh
 End Sub
@@ -169,7 +168,7 @@ Private Function ExtractZoteroPrefData() As String
             dict(prop.Name) = prop.Value
         End If
     Next prop
-    
+
     Dim sortedKeys As Variant
     sortedKeys = dict.Keys
     Call QuickSort(sortedKeys, LBound(sortedKeys), UBound(sortedKeys))
@@ -205,7 +204,7 @@ Private Function GetZoteroPrefsFromXml(zoteroData As String) As Object
         dict("data-version") = dataElem.getAttribute("data-version")
         dict("zotero-version") = dataElem.getAttribute("zotero-version")
     End If
-    
+
     Dim sessionElem As Object
     Set sessionElem = xmlDoc.SelectSingleNode("//session")
     If Not sessionElem Is Nothing Then
@@ -285,7 +284,7 @@ Private Function RemoveSpecifiedHtmlTags(inputString As String, tagsToRemove As 
             inputString = .Replace(inputString, "")
         End With
     Next tag
-    
+
     RemoveSpecifiedHtmlTags = inputString
 End Function
 
@@ -355,8 +354,8 @@ Private Function ParseCSLCitationJson(ByVal code As String) As Object
     Set ParseCSLCitationJson = jsonObj
 End Function
 
-Function StyleExists(ByVal styleToTest As String, ByVal docToTest as Word.Document) As Boolean
-    Dim testStyle as Word.Style
+Function StyleExists(ByVal styleToTest As String, ByVal docToTest As Word.Document) As Boolean
+    Dim testStyle As Word.style
     On Error Resume Next
     Set testStyle = docToTest.Styles(styleToTest)
     StyleExists = Not testStyle Is Nothing
@@ -367,10 +366,10 @@ End Function
 '-------------------------------------------------------------------
 
 ' Such as (Dweba et al., 2017; Hu et al., 2022; Moonjely et al., 2023)
-Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Citation, _
+Private Sub ExtractAuthorYearCitations(field As field, ByRef citations() As Citation, _
         Optional onlyYear As Boolean = False, Optional multiRefCommaSep As Boolean = True)
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.Result
+    Set targetRange = field.result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -384,12 +383,12 @@ Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Cita
     beginYear = False
 
     Dim json As Object
-    Set json = ParseCSLCitationJson(field.Code)
+    Set json = ParseCSLCitationJson(field.code)
 
     Dim startChar As Long, endChar As Long
 
     Dim i As Long
-    For i = 1 To targetRange.Characters.Count
+    For i = 1 To targetRange.Characters.count
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
@@ -405,7 +404,7 @@ Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Cita
             If onlyYear And Not inCitation Then
                 inCitation = True
                 startChar = charRange.Start
-            EndIf
+            End If
 
         ' Check multiple citations of same author
         ElseIf multiRefCommaSep And charRange.Text = "," Then
@@ -419,7 +418,7 @@ Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Cita
             beginYear = False
             If multiRefCommaSep Then nComma = 0
 
-        CreateCitationObject:
+CreateCitationObject:
             If inCitation Then
                 endChar = charRange.Start
 
@@ -451,9 +450,9 @@ Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Cita
 End Sub
 
 ' Such as [1], [2], [3] etc.
-Private Sub ExtractNumberInBrackets(field As Field, ByRef citations() As Citation, Optional bracket As String = "[]")
+Private Sub ExtractNumberInBrackets(field As field, ByRef citations() As Citation, Optional bracket As String = "[]")
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.Result
+    Set targetRange = field.result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -474,7 +473,7 @@ Private Sub ExtractNumberInBrackets(field As Field, ByRef citations() As Citatio
     Dim startChar As Long, endChar As Long
 
     Dim i As Long
-    For i = 1 To targetRange.Characters.Count
+    For i = 1 To targetRange.Characters.count
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
@@ -505,10 +504,10 @@ Private Sub ExtractNumberInBrackets(field As Field, ByRef citations() As Citatio
 
 End Sub
 
-' Such as [47,98,100–102]
-Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Citation, Optional border = "")
+' Such as [47,98,100鈥?02]
+Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Citation, Optional border = "")
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.Result
+    Set targetRange = field.result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -528,7 +527,7 @@ Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Ci
     lastNum = 0
 
     Dim json As Object
-    Set json = ParseCSLCitationJson(field.Code)
+    Set json = ParseCSLCitationJson(field.code)
 
     Dim startChar As Long, endChar As Long
 
@@ -536,24 +535,24 @@ Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Ci
     Dim citationText As String
 
     Dim i As Long, RL As Long
-    RL = targetRange.Characters.Count
+    RL = targetRange.Characters.count
 
     ' Add a pseudo-border to the citation text without borders
     If Len(endBorder) = 0 Then
         RL = RL + 1
         endBorder = "]"
-    EndIf
+    End If
 
     For i = 1 To RL
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
-        If i <= targetRange.Characters.Count Then
+        If i <= targetRange.Characters.count Then
             currentChar = charRange.Text
         Else
             ' Point to the psuedo-border
             currentChar = endBorder
-        EndIf
+        End If
 
         If currentChar Like "[0-9]" And Not inCitation Then
             inCitation = True
@@ -588,7 +587,7 @@ Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Ci
 
                 If Len(citations(rangeIndex).BibPattern) = 0 Then
                     Err.Raise vbObjectError + 1, "ExtractCitations", "Can not find citation CSL data"
-                EndIf
+                End If
 
                 inCitation = False
             End If
@@ -604,7 +603,13 @@ Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Ci
 
     Next i
 
-    ReDim Preserve citations(0 To rangeIndex)
+    If rangeIndex >= 0 Then
+        ReDim Preserve citations(0 To rangeIndex)
+    Else
+        ' 没有找到任何引用，初始化为空数组
+        ReDim citations(-1 To -1)
+    End If
+
 End Sub
 
 '-------------------------------------------------------------------
@@ -619,12 +624,13 @@ Private Function isSupportedStyle(ByVal style As String) As Boolean
         "american-sociological-association|chicago-author-date|bmc-medicine|" & _
         "china-national-standard-gb-t-7714-2015-numeric|" & _
         "china-national-standard-gb-t-7714-2015-author-date|" & _
-        "harvard-cite-them-right|elsevier-harvard|modern-language-association|"
+        "harvard-cite-them-right|elsevier-harvard|modern-language-association|" & _
+        "multidisciplinary-digital-publishing-institute|"
     style = "|" & style & "|"
     isSupportedStyle = InStr(1, predefinedList, style, vbTextCompare) > 0
 End Function
 
-Private Sub ExtractCitations(field As Field, ByRef citations() As Citation, style As String)
+Private Sub ExtractCitations(field As field, ByRef citations() As Citation, style As String)
     Select Case style
         Case "molecular-plant", "chicago-author-date", "modern-language-association"
             Call ExtractAuthorYearCitations(field, citations, onlyYear:=False, multiRefCommaSep:=False)
@@ -643,7 +649,7 @@ Private Sub ExtractCitations(field As Field, ByRef citations() As Citation, styl
         Case "vancouver"
             Call ExtractSerialNumberCitations(field, citations, "()")
 
-        Case "china-national-standard-gb-t-7714-2015-numeric", "bmc-medicine"
+        Case "china-national-standard-gb-t-7714-2015-numeric", "bmc-medicine", "multidisciplinary-digital-publishing-institute"
             Call ExtractSerialNumberCitations(field, citations, "[]")
 
         Case "american-chemical-society", "american-medical-association", "nature"
@@ -659,14 +665,14 @@ End Sub
 '-------------------------------------------------------------------
 
 Public Sub ZoteroLinkCitationWithinSelection()
-    If Selection.Fields.Count > 0 Then
+    If Selection.Fields.count > 0 Then
         Dim originalRng As Range
         Set originalRng = Selection.Range
 
         Application.ScreenUpdating = False
 
         Dim targetFields As New Collection
-        Dim fld As Field
+        Dim fld As field
 
         For Each fld In Selection.Fields
             targetFields.Add fld
@@ -726,23 +732,23 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
     If notify Then
         Dim resp As String
-        resp = InputBox(title := "Set an MS Word style for hyperlinks?", _
-                        prompt := "If you want to set a certain style for hyperlinks," & _
+        resp = InputBox(title:="Set an MS Word style for hyperlinks?", _
+                        prompt:="If you want to set a certain style for hyperlinks," & _
                                     " enter the name of that style below.")
         If StyleExists(resp, ActiveDocument) Then userTextStyle = resp
     End If
 
     Dim i As Long
-    Dim bibField As Field
+    Dim bibField As field
     Set bibField = Nothing
 
     ' Find the Zotero bibliography field
-    For i = ActiveDocument.Fields.Count To 1 Step -1
+    For i = ActiveDocument.Fields.count To 1 Step -1
         If ActiveDocument.Fields(i).Type = wdFieldAddin Then
-            If InStr(ActiveDocument.Fields(i).Code, "ADDIN ZOTERO_BIBL") > 0 Then
+            If InStr(ActiveDocument.Fields(i).code, "ADDIN ZOTERO_BIBL") > 0 Then
                 Set bibField = ActiveDocument.Fields(i)
                 Exit For
-            EndIf
+            End If
         End If
     Next i
 
@@ -751,23 +757,23 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
     End If
 
     ' Iterate through all fields in the document
-    Dim aField As Field, iCount As Integer
+    Dim aField As field, iCount As Integer
     For Each aField In targetFields
         ' Check if the field is a Zotero citation
         If aField.Type = wdFieldAddin Then
-            If InStr(aField.Code, "ADDIN ZOTERO_ITEM") > 0 Then
+            If InStr(aField.code, "ADDIN ZOTERO_ITEM") > 0 Then
 
                 If debugging Then
                     ' Focus to next field
                     Application.ScreenUpdating = True
-                    ActiveWindow.ScrollIntoView aField.Result, True
-                    aField.Result.Select
+                    ActiveWindow.ScrollIntoView aField.result, True
+                    aField.result.Select
 
                     ' Update the document
                     DoEvents
 
-                    If MsgBox("Processed " & iCount & " citations, and found the next group:" & vbCrLf & vbCrLf & _ 
-                                aField.Result.Text & vbCrLf & vbCrLf & "Do you want to continue?", _
+                    If MsgBox("Processed " & iCount & " citations, and found the next group:" & vbCrLf & vbCrLf & _
+                                aField.result.Text & vbCrLf & vbCrLf & "Do you want to continue?", _
                                 vbYesNo + vbQuestion, "Continue?") = vbNo Then
                         Exit For
                     End If
@@ -783,7 +789,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
                 For i = 0 To UBound(cits)
                     cit = cits(i)
                     Dim rng As Range
-                    Set rng = aField.Result.Document.Range(Start:=cit.Start, End:=cit.End)
+                    Set rng = aField.result.Document.Range(Start:=cit.Start, End:=cit.End)
                     tempBookmarkName = "ZoteroLinkCitationTempBookmark" & i
                     ActiveDocument.Bookmarks.Add Name:=tempBookmarkName, Range:=rng
                 Next i
@@ -801,7 +807,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
                     ' Get the range of Zotero bibliography
                     Dim rngBibliography As Range
-                    Set rngBibliography = bibField.Result
+                    Set rngBibliography = bibField.result
 
                     With rngBibliography.Find
                         .ClearFormatting
@@ -848,7 +854,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
                     iCount = iCount + 1
 
-                SkipToNextCitation:
+SkipToNextCitation:
                     ActiveDocument.Bookmarks("ZoteroLinkCitationTempBookmark" & i).Delete
 
                 Next i
@@ -862,3 +868,5 @@ ExitTheMacro:
     If notify Then MsgBox "Linked " & iCount & " Zotero citations.", vbInformation, "Finish"
 
 End Sub
+
+

--- a/ZoteroLinkCitation.bas
+++ b/ZoteroLinkCitation.bas
@@ -1,3 +1,4 @@
+Attribute VB_Name = "ZoteroLinkCitation"
 ' An MS Word macro that links author-date or number style citations to their bibliography entry.
 ' altair_wei@outlook.com
 ' https://github.com/altairwei/ZoteroLinkCitation

--- a/ZoteroLinkCitation.bas
+++ b/ZoteroLinkCitation.bas
@@ -44,7 +44,7 @@ Private Function ParseObj(key$)
                        Else
                            ParseObj key
                        End If
-
+                
             Case "}":  key = ReducePath(key): Exit Do
             Case ":":  key = key & "." & token(p - 1)
             Case ",":  key = ReducePath(key)
@@ -87,11 +87,11 @@ Private Function RExtract(s$, Pattern, Optional bGroup1Bias As Boolean, Optional
     .Pattern = Pattern
     If .TEST(s) Then
       Set m = .Execute(s)
-      ReDim v(1 To m.count)
+      ReDim v(1 To m.Count)
       For Each n In m
         c = c + 1
-        v(c) = n.Value
-        If bGroup1Bias Then If Len(n.submatches(0)) Or n.Value = """""" Then v(c) = n.submatches(0)
+        v(c) = n.value
+        If bGroup1Bias Then If Len(n.submatches(0)) Or n.value = """""" Then v(c) = n.submatches(0)
       Next
     End If
   End With
@@ -226,8 +226,8 @@ End Function
 
 Function GetFilteredValues(dic, match)
     Dim c&, i&, v, w
-    v = dic.Keys
-    ReDim w(1 To dic.count)
+    v = dic.keys
+    ReDim w(1 To dic.Count)
     For i = 0 To UBound(v)
         If v(i) Like match Then
             c = c + 1
@@ -240,7 +240,7 @@ End Function
 
 Function GetFilteredTable(dic, cols)
     Dim c&, i&, j&, v, w, z
-    v = dic.Keys
+    v = dic.keys
     z = GetFilteredValues(dic, cols(0))
     ReDim w(1 To UBound(z), 1 To UBound(cols) + 1)
     For j = 1 To UBound(cols) + 1
@@ -261,20 +261,20 @@ Private Sub QuickSort(arr As Variant, inLow As Long, inHigh As Long)
     Dim tmpSwap As Variant
     Dim low As Long
     Dim high As Long
-
+    
     low = inLow
     high = inHigh
     pivot = arr((low + high) \ 2)
-
+    
     While (low <= high)
         While (arr(low) < pivot And low < inHigh)
             low = low + 1
         Wend
-
+        
         While (pivot < arr(high) And high > inLow)
             high = high - 1
         Wend
-
+        
         If (low <= high) Then
             tmpSwap = arr(low)
             arr(low) = arr(high)
@@ -283,7 +283,7 @@ Private Sub QuickSort(arr As Variant, inLow As Long, inHigh As Long)
             high = high - 1
         End If
     Wend
-
+    
     If (inLow < high) Then QuickSort arr, inLow, high
     If (low < inHigh) Then QuickSort arr, low, inHigh
 End Sub
@@ -298,7 +298,7 @@ Private Function ExtractZoteroPrefData() As String
             dict.Item(prop.Name) = prop.Value
         End If
     Next prop
-
+    
     Dim sortedKeys As Variant
     sortedKeys = dict.Keys
     Call QuickSort(sortedKeys, LBound(sortedKeys), UBound(sortedKeys))
@@ -538,7 +538,6 @@ Private Function RemoveSpecifiedHtmlTags(inputString As String, tagsToRemove As 
         Next tag
     #End If
 
-
     RemoveSpecifiedHtmlTags = inputString
 End Function
 
@@ -608,8 +607,8 @@ Private Function ParseCSLCitationJson(ByVal code As String) As Object
     Set ParseCSLCitationJson = jsonObj
 End Function
 
-Function StyleExists(ByVal styleToTest As String, ByVal docToTest As Word.Document) As Boolean
-    Dim testStyle As Word.style
+Function StyleExists(ByVal styleToTest As String, ByVal docToTest as Word.Document) As Boolean
+    Dim testStyle as Word.Style
     On Error Resume Next
     Set testStyle = docToTest.Styles(styleToTest)
     StyleExists = Not testStyle Is Nothing
@@ -620,10 +619,10 @@ End Function
 '-------------------------------------------------------------------
 
 ' Such as (Dweba et al., 2017; Hu et al., 2022; Moonjely et al., 2023)
-Private Sub ExtractAuthorYearCitations(field As field, ByRef citations() As Citation, _
+Private Sub ExtractAuthorYearCitations(field As Field, ByRef citations() As Citation, _
         Optional onlyYear As Boolean = False, Optional multiRefCommaSep As Boolean = True)
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.result
+    Set targetRange = field.Result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -637,12 +636,12 @@ Private Sub ExtractAuthorYearCitations(field As field, ByRef citations() As Cita
     beginYear = False
 
     Dim json As Object
-    Set json = ParseCSLCitationJson(field.code)
+    Set json = ParseCSLCitationJson(field.Code)
 
     Dim startChar As Long, endChar As Long
 
     Dim i As Long
-    For i = 1 To targetRange.Characters.count
+    For i = 1 To targetRange.Characters.Count
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
@@ -658,7 +657,7 @@ Private Sub ExtractAuthorYearCitations(field As field, ByRef citations() As Cita
             If onlyYear And Not inCitation Then
                 inCitation = True
                 startChar = charRange.Start
-            End If
+            EndIf
 
         ' Check multiple citations of same author
         ElseIf multiRefCommaSep And charRange.Text = "," Then
@@ -672,7 +671,7 @@ Private Sub ExtractAuthorYearCitations(field As field, ByRef citations() As Cita
             beginYear = False
             If multiRefCommaSep Then nComma = 0
 
-CreateCitationObject:
+        CreateCitationObject:
             If inCitation Then
                 endChar = charRange.Start
 
@@ -700,13 +699,17 @@ CreateCitationObject:
     Next i
 
     ' Resize the array to fit the number of found ranges
-    ReDim Preserve citations(0 To rangeIndex)
+    If rangeIndex >= 0 Then
+        ReDim Preserve citations(0 To rangeIndex)
+    Else
+        ReDim citations(-1 To -1)
+    End If
 End Sub
 
 ' Such as [1], [2], [3] etc.
-Private Sub ExtractNumberInBrackets(field As field, ByRef citations() As Citation, Optional bracket As String = "[]")
+Private Sub ExtractNumberInBrackets(field As Field, ByRef citations() As Citation, Optional bracket As String = "[]")
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.result
+    Set targetRange = field.Result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -727,7 +730,7 @@ Private Sub ExtractNumberInBrackets(field As field, ByRef citations() As Citatio
     Dim startChar As Long, endChar As Long
 
     Dim i As Long
-    For i = 1 To targetRange.Characters.count
+    For i = 1 To targetRange.Characters.Count
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
@@ -754,14 +757,18 @@ Private Sub ExtractNumberInBrackets(field As field, ByRef citations() As Citatio
     Next i
 
     ' Resize the array to fit the number of found ranges
-    ReDim Preserve citations(0 To rangeIndex)
+    If rangeIndex >= 0 Then
+        ReDim Preserve citations(0 To rangeIndex)
+    Else
+        ReDim citations(-1 To -1)
+    End If
 
 End Sub
 
-' Such as [47,98,100鈥?02]
-Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Citation, Optional border = "")
+' Such as [47,98,100–102]
+Private Sub ExtractSerialNumberCitations(field As Field, ByRef citations() As Citation, Optional border = "")
     Dim targetRange As Range, charRange As Range
-    Set targetRange = field.result
+    Set targetRange = field.Result
     Set charRange = targetRange.Duplicate
     charRange.Collapse wdCollapseStart
 
@@ -781,7 +788,7 @@ Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Ci
     lastNum = 0
 
     Dim json As Object
-    Set json = ParseCSLCitationJson(field.code)
+    Set json = ParseCSLCitationJson(field.Code)
 
     Dim startChar As Long, endChar As Long
 
@@ -789,24 +796,24 @@ Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Ci
     Dim citationText As String
 
     Dim i As Long, RL As Long
-    RL = targetRange.Characters.count
+    RL = targetRange.Characters.Count
 
     ' Add a pseudo-border to the citation text without borders
     If Len(endBorder) = 0 Then
         RL = RL + 1
         endBorder = "]"
-    End If
+    EndIf
 
     For i = 1 To RL
         charRange.Start = targetRange.Start + i - 1
         charRange.End = targetRange.Start + i
 
-        If i <= targetRange.Characters.count Then
+        If i <= targetRange.Characters.Count Then
             currentChar = charRange.Text
         Else
             ' Point to the psuedo-border
             currentChar = endBorder
-        End If
+        EndIf
 
         If currentChar Like "[0-9]" And Not inCitation Then
             inCitation = True
@@ -841,7 +848,7 @@ Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Ci
 
                 If Len(citations(rangeIndex).BibPattern) = 0 Then
                     Err.Raise vbObjectError + 1, "ExtractCitations", "Can not find citation CSL data"
-                End If
+                EndIf
 
                 inCitation = False
             End If
@@ -860,10 +867,8 @@ Private Sub ExtractSerialNumberCitations(field As field, ByRef citations() As Ci
     If rangeIndex >= 0 Then
         ReDim Preserve citations(0 To rangeIndex)
     Else
-        ' 没有找到任何引用，初始化为空数组
         ReDim citations(-1 To -1)
     End If
-
 End Sub
 
 '-------------------------------------------------------------------
@@ -886,7 +891,7 @@ Private Function isSupportedStyle(ByVal style As String) As Boolean
     isSupportedStyle = InStr(1, predefinedList, style, vbTextCompare) > 0
 End Function
 
-Private Sub ExtractCitations(field As field, ByRef citations() As Citation, style As String)
+Private Sub ExtractCitations(field As Field, ByRef citations() As Citation, style As String)
     Select Case style
         Case "molecular-plant", "chicago-author-date", "modern-language-association"
             Call ExtractAuthorYearCitations(field, citations, onlyYear:=False, multiRefCommaSep:=False)
@@ -923,14 +928,14 @@ End Sub
 '-------------------------------------------------------------------
 
 Public Sub ZoteroLinkCitationWithinSelection()
-    If Selection.Fields.count > 0 Then
+    If Selection.Fields.Count > 0 Then
         Dim originalRng As Range
         Set originalRng = Selection.Range
 
         Application.ScreenUpdating = False
 
         Dim targetFields As New Collection
-        Dim fld As field
+        Dim fld As Field
 
         For Each fld In Selection.Fields
             targetFields.Add fld
@@ -1004,23 +1009,23 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
     If notify Then
         Dim resp As String
-        resp = InputBox(title:="Set an MS Word style for hyperlinks?", _
-                        prompt:="If you want to set a certain style for hyperlinks," & _
+        resp = InputBox(title := "Set an MS Word style for hyperlinks?", _
+                        prompt := "If you want to set a certain style for hyperlinks," & _
                                     " enter the name of that style below.")
         If StyleExists(resp, ActiveDocument) Then userTextStyle = resp
     End If
 
     Dim i As Long
-    Dim bibField As field
+    Dim bibField As Field
     Set bibField = Nothing
 
     ' Find the Zotero bibliography field
-    For i = ActiveDocument.Fields.count To 1 Step -1
+    For i = ActiveDocument.Fields.Count To 1 Step -1
         If ActiveDocument.Fields(i).Type = wdFieldAddin Then
-            If InStr(ActiveDocument.Fields(i).code, "ADDIN ZOTERO_BIBL") > 0 Then
+            If InStr(ActiveDocument.Fields(i).Code, "ADDIN ZOTERO_BIBL") > 0 Then
                 Set bibField = ActiveDocument.Fields(i)
                 Exit For
-            End If
+            EndIf
         End If
     Next i
 
@@ -1029,23 +1034,23 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
     End If
 
     ' Iterate through all fields in the document
-    Dim aField As field, iCount As Integer
+    Dim aField As Field, iCount As Integer
     For Each aField In targetFields
         ' Check if the field is a Zotero citation
         If aField.Type = wdFieldAddin Then
-            If InStr(aField.code, "ADDIN ZOTERO_ITEM") > 0 Then
+            If InStr(aField.Code, "ADDIN ZOTERO_ITEM") > 0 Then
 
                 If debugging Then
                     ' Focus to next field
                     Application.ScreenUpdating = True
-                    ActiveWindow.ScrollIntoView aField.result, True
-                    aField.result.Select
+                    ActiveWindow.ScrollIntoView aField.Result, True
+                    aField.Result.Select
 
                     ' Update the document
                     DoEvents
 
-                    If MsgBox("Processed " & iCount & " citations, and found the next group:" & vbCrLf & vbCrLf & _
-                                aField.result.Text & vbCrLf & vbCrLf & "Do you want to continue?", _
+                    If MsgBox("Processed " & iCount & " citations, and found the next group:" & vbCrLf & vbCrLf & _ 
+                                aField.Result.Text & vbCrLf & vbCrLf & "Do you want to continue?", _
                                 vbYesNo + vbQuestion, "Continue?") = vbNo Then
                         Exit For
                     End If
@@ -1061,7 +1066,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
                 For i = 0 To UBound(cits)
                     cit = cits(i)
                     Dim rng As Range
-                    Set rng = aField.result.Document.Range(Start:=cit.Start, End:=cit.End)
+                    Set rng = aField.Result.Document.Range(Start:=cit.Start, End:=cit.End)
                     tempBookmarkName = "ZoteroLinkCitationTempBookmark" & i
                     ActiveDocument.Bookmarks.Add Name:=tempBookmarkName, Range:=rng
                 Next i
@@ -1079,7 +1084,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
                     ' Get the range of Zotero bibliography
                     Dim rngBibliography As Range
-                    Set rngBibliography = bibField.result
+                    Set rngBibliography = bibField.Result
 
                     With rngBibliography.Find
                         .ClearFormatting
@@ -1130,7 +1135,7 @@ Private Sub ZoteroLinkCitation(targetFields, Optional debugging As Boolean = Fal
 
                     iCount = iCount + 1
 
-SkipToNextCitation:
+                SkipToNextCitation:
                     ActiveDocument.Bookmarks("ZoteroLinkCitationTempBookmark" & i).Delete
 
                 Next i
@@ -1144,5 +1149,3 @@ ExitTheMacro:
     If notify Then MsgBox "Linked " & iCount & " Zotero citations.", vbInformation, "Finish"
 
 End Sub
-
-


### PR DESCRIPTION

### **Pull Request 描述 (Description):**

This pull request introduces two key improvements to the macro:

#### 1. Added Support for MDPI (Multidisciplinary Digital Publishing Institute) Citation Style

The MDPI citation style is a numbered format enclosed in square brackets, such as `[1]`, `[2]`, etc. This format is functionally identical to the `china-national-standard-gb-t-7714-2015-numeric` and `bmc-medicine` styles already supported by the `ExtractSerialNumberCitations` function.

To implement this, I've added `multidisciplinary-digital-publishing-institute` to the existing `Case` statement, allowing the macro to correctly parse MDPI-style citations.

**Before:**
Running the macro on a document with the MDPI style would result in a "Citation style not recognized" error.

**After:**
The macro now correctly processes citations for documents using the MDPI style.

```vb
' Changes in Private Sub ExtractCitations
' ...
        Case "china-national-standard-gb-t-7714-2015-numeric", "bmc-medicine", "multidisciplinary-digital-publishing-institute"
            Call ExtractSerialNumberCitations(field, citations, "[]")
' ...
```

#### 2. Fixed "Subscript Out of Range" Error on Subsequent Runs

When running the macro for a second time within the same session on a document where no new citations are found, the `rangeIndex` variable correctly remains at its initial value of `-1`. However, the final `ReDim Preserve citations(0 To rangeIndex)` statement would attempt to execute `ReDim Preserve citations(0 To -1)`, causing a "subscript out of range" runtime error.

I have resolved this by adding a conditional check before the final `ReDim Preserve`. The array is now only resized if `rangeIndex` is greater than or equal to `0` (meaning at least one citation was found). If no citations are found, the `citations` array is safely re-dimensioned as an empty array to prevent errors.

This change has been applied to all three citation extraction functions:

- `ExtractAuthorYearCitations`
- `ExtractNumberInBrackets`
- `ExtractSerialNumberCitations`

**Example of the fix in `ExtractSerialNumberCitations`:**

```vb
' Old code at the end of the function:
ReDim Preserve citations(0 To rangeIndex)

' New code at the end of the function:
If rangeIndex >= 0 Then
    ReDim Preserve citations(0 To rangeIndex)
Else
    ' Re-dimension as an empty array if no citations were found
    ReDim citations(-1 To -1)
End If
```

These changes make the macro more robust and extend its compatibility, improving the overall user experience.